### PR TITLE
derive: Switch to running git subprocesses

### DIFF
--- a/git-testament-derive/Cargo.toml
+++ b/git-testament-derive/Cargo.toml
@@ -15,7 +15,6 @@ maintenance = { status = "experimental" }
 [dependencies]
 syn = "0.15"
 quote = "0.6"
-git2 = { version = "0.8", default-features = false }
 chrono = "0.4"
 log = "0.4"
 


### PR DESCRIPTION
Ideally we'd stick with libgit2 but for now we'll run git
subprocesses since that's more reliable with rls and we don't
want to break rls for our users.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>