### PR TITLE
Make crate `no_std` compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-testament"
-version = "0.1.9"
+version = "0.2.0"
 authors = ["Daniel Silverstone <dsilvers@digital-scurf.org>"]
 edition = "2018"
 
@@ -20,7 +20,8 @@ members = [
 ]
 
 [dependencies]
-git-testament-derive = { version = "0.1.9", path = "git-testament-derive" }
+no-std-compat = { version = "0.4" }
+git-testament-derive = { version = "0.1.11", path = "git-testament-derive" }
 
 [dev-dependencies]
 tempdir = "0.3.7"
@@ -29,5 +30,5 @@ regex = "1"
 lazy_static = "1"
 
 [features]
-default = []
-no-std = []
+alloc = ["no-std-compat/alloc"]
+default = ["alloc"]

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ as a number of seconds since the UNIX epoch) to override `now`.
 
 ## Use in `no_std` scenarios
 
-If you turn on the `git-testament/no-std` feature then the crate will not link to
-anything in the standard library.  You can still generate a `GitTestament` struct
-though it'll be less easy to work with.  Instead it'd be recommended to use the
-`git_testament_macros!()` macro instead which provides a set of macros which produce
-string constants to use.  This is less flexible/capable but can sometimes be easier
-to work with in these kinds of situations.
+This crate does not link to anything in the standard library, but it does rely by default
+on the `alloc` library being available. Disabling the `alloc` feature allows the crate to work 
+in `no_std` environments where the `alloc` library is not available.
+You can still generate a `GitTestament` struct though it'll be less easy to work with.
+Instead it'd be recommended to use the `git_testament_macros!()` macro instead 
+which provides a set of macros which produce string constants to use.
+This is less flexible/capable but can sometimes be easier to work with in these kinds of situations.

--- a/git-testament-derive/Cargo.toml
+++ b/git-testament-derive/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Daniel Silverstone <dsilvers@digital-scurf.org>"]
 edition = "2018"
 name = "git-testament-derive"
-version = "0.1.10"
+version = "0.1.11"
 
 description = "Record git working tree status when compiling your crate - inner procedural macro"
 documentation = "https://docs.rs/git-testament/"
@@ -19,10 +19,10 @@ syn = "1.0"
 quote = "1.0"
 chrono = "0.4"
 log = "0.4"
-proc-macro2 = "1"
+proc-macro2 = "1.0"
 
 [dev-dependencies]
-git-testament = { version="0.1.9", path = ".." }
+git-testament = { version = "0.2", path = ".." }
 
 [lib]
 proc-macro = true

--- a/test-template/Cargo.toml
+++ b/test-template/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [workspace]
 
 [features]
-no-std = [ "git-testament/no-std" ]
+default = ["alloc"]
+alloc = ["git-testament/alloc"]
 
 [dependencies]

--- a/test-template/src/main.rs
+++ b/test-template/src/main.rs
@@ -1,14 +1,14 @@
-#[cfg(not(feature = "no-std"))]
+#[cfg(feature = "alloc")]
 use git_testament::{git_testament, render_testament};
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(feature = "alloc")]
 git_testament!(TESTAMENT);
 
 use git_testament::git_testament_macros;
 
 git_testament_macros!(version, "trusted");
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(feature = "alloc")]
 fn main() {
     assert_eq!(
         format!("{}", render_testament!(TESTAMENT, "trusted")),
@@ -17,7 +17,7 @@ fn main() {
     println!("{}", render_testament!(TESTAMENT, "trusted"));
 }
 
-#[cfg(feature = "no-std")]
+#[cfg(not(feature = "alloc"))]
 fn main() {
     println!("{}", concat!("", version_testament!()));
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -9,6 +9,8 @@ fn it_works() {
     println!("Testament: {}", TESTAMENT);
 }
 
+//testament macro is not guaranteed to be indentical to testament's Display in `no_std`
+#[cfg(feature = "alloc")]
 #[test]
 fn macros_work() {
     assert_eq!(format!("{}", TESTAMENT), version_testament!());


### PR DESCRIPTION
The current implementation of the crate is not `no_std` compatible, since it is not marked with the`#![no_std]` attribute.

This PR addresses that, as well as improving the crate in general:

- Code now relies on `no_std_compat` to simplify no_std/alloc/std management
- A new feature was added `alloc`, enabled by default, which adds what the `no_std` feature previously removed
- The crate is now compatible with `no_std` + `alloc`, so `std` is not required at all
- Touched up the `Display` impls a bit to make use of the `write!` macro

Tests were updated and one test was removed when the `alloc` crate is not present, as it would fail in certain repository conditions, as expected.