### PR TITLE
Fix CVE-2020-26235

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-testament"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Daniel Silverstone <dsilvers@digital-scurf.org>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ members = [
 
 [dependencies]
 no-std-compat = { version = "0.4" }
-git-testament-derive = { version = "0.1.11", path = "git-testament-derive" }
+git-testament-derive = { version = "0.1.13", path = "git-testament-derive" }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/git-testament-derive/Cargo.toml
+++ b/git-testament-derive/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Daniel Silverstone <dsilvers@digital-scurf.org>"]
 edition = "2018"
 name = "git-testament-derive"
-version = "0.1.12"
+version = "0.1.13"
 
 description = "Record git working tree status when compiling your crate - inner procedural macro"
 documentation = "https://docs.rs/git-testament/"
@@ -18,7 +18,7 @@ log = "0.4"
 proc-macro2 = "1.0"
 
 [dev-dependencies]
-git-testament = { version = "0.2", path = ".." }
+git-testament = { version = "0.2.1", path = ".." }
 
 [lib]
 proc-macro = true

--- a/git-testament-derive/Cargo.toml
+++ b/git-testament-derive/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 syn = "1.0"
 quote = "1.0"
-chrono = "0.4"
+time = { version = "0.3", features = ["formatting", "macros"] }
 log = "0.4"
 proc-macro2 = "1.0"
 


### PR DESCRIPTION
This PR closes #17 

`chrono` doesn't seem to be maintained anymore so it was replaced with `time`, and all functionality has been rewritten in terms of `time`, preserving the same functionality and output exactly as it was with `chrono`, as far as I'm aware of.

I have bumped the patch version as this doesn't change the public API in any way