### PR TITLE
Switch from deprecated tempdir to tempfile (RUSTSEC-2018-0017)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ no-std-compat = { version = "0.4" }
 git-testament-derive = { version = "0.1.13", path = "git-testament-derive" }
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3"
 rand = "0.8"
 regex = "1"
 lazy_static = "1"

--- a/tests/testutils.rs
+++ b/tests/testutils.rs
@@ -5,7 +5,8 @@ use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::process::{Command, Stdio};
-use tempdir::TempDir;
+use tempfile::Builder;
+use tempfile::TempDir;
 
 pub struct TestSentinel {
     dir: Option<TempDir>,
@@ -40,11 +41,10 @@ lazy_static! {
 }
 
 pub fn prep_test(name: &str) -> TestSentinel {
-    let outdir = TempDir::new_in(
-        env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_owned()),
-        &format!("test-{}-", name),
-    )
-    .expect("Unable to create temporary directory for test");
+    let outdir = Builder::new()
+        .prefix(&format!("test-{}-", name))
+        .tempdir_in(env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_owned()))
+        .expect("Unable to create temporary directory for test");
 
     let mut rng = thread_rng();
     let mut name = (0..10)


### PR DESCRIPTION
 Closes https://github.com/kinnison/git-testament/issues/19