### PR TITLE
Make `git_testament!(…)` generate `const`

### DIFF
--- a/git-testament-derive/src/lib.rs
+++ b/git-testament-derive/src/lib.rs
@@ -323,7 +323,7 @@ pub fn git_testament(input: TokenStream) -> TokenStream {
             );
             return (quote! {
                 #[allow(clippy::needless_update)]
-                static #name: #crate_::GitTestament<'static> = #crate_::GitTestament {
+                const #name: #crate_::GitTestament<'static> = #crate_::GitTestament {
                     commit: #crate_::CommitKind::NoRepository(#pkgver, #now),
                     .. #crate_::EMPTY_TESTAMENT
                 };
@@ -345,7 +345,7 @@ pub fn git_testament(input: TokenStream) -> TokenStream {
     if gitinfo.commitinfo.is_none() {
         return (quote! {
             #[allow(clippy::needless_update)]
-            static #name: #crate_::GitTestament<'static> = #crate_::GitTestament {
+            const #name: #crate_::GitTestament<'static> = #crate_::GitTestament {
                 commit: #crate_::CommitKind::NoCommit(#pkgver, #now),
                 branch_name: #branch_name,
                 .. #crate_::EMPTY_TESTAMENT
@@ -399,7 +399,7 @@ pub fn git_testament(input: TokenStream) -> TokenStream {
 
     (quote! {
         #[allow(clippy::needless_update)]
-        static #name: #crate_::GitTestament<'static> = #crate_::GitTestament {
+        const #name: #crate_::GitTestament<'static> = #crate_::GitTestament {
             commit: #commit,
             modifications: &[#(#statuses),*],
             branch_name: #branch_name,

--- a/tests/const.rs
+++ b/tests/const.rs
@@ -1,0 +1,27 @@
+use git_testament::{git_testament, git_testament_macros};
+
+git_testament!(TESTAMENT);
+
+git_testament_macros!(TESTAMENT);
+
+const TESTAMENT_BRANCH_NAME_OR_DEFAULT: &str = {
+    match TESTAMENT.branch_name {
+        Some(branch_name) => branch_name,
+        None => "main",
+    }
+};
+
+const MACROS_BRANCH_NAME_OR_DEFAULT: &str = {
+    match TESTAMENT_branch!() {
+        Some(branch_name) => branch_name,
+        None => "main",
+    }
+};
+
+#[test]
+fn it_works() {
+    assert_eq!(
+        TESTAMENT_BRANCH_NAME_OR_DEFAULT,
+        MACROS_BRANCH_NAME_OR_DEFAULT
+    );
+}


### PR DESCRIPTION
This way the testament can be used in `const fn`.